### PR TITLE
add RTINMINUTES per massTools issue #2

### DIFF
--- a/R/read_mgf.R
+++ b/R/read_mgf.R
@@ -51,7 +51,7 @@ read_mgf <- function(file) {
         })
       info.rt <-
         lapply(mgf.data, function(x) {
-          grep("^RTINSECONDS|RETENTIONTIME", x, value = TRUE)
+          grep("^RTINSECONDS|RETENTIONTIME|RTINMINUTES", x, value = TRUE)
         })
       
       info.mz <- unlist(info.mz) %>% 


### PR DESCRIPTION
RTINMINUTES was added to the retention time string search of .mgf file.